### PR TITLE
Convert SBomException to a runtime exception

### DIFF
--- a/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/exceptions/SBomException.java
+++ b/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/exceptions/SBomException.java
@@ -15,7 +15,7 @@ package org.cyclonedx.contrib.com.lmco.efoss.unix.sbom.exceptions;
  * @author wrgoff
  * @since 22 April 2020
  */
-public class SBomException extends Exception
+public class SBomException extends RuntimeException
 {
 	private static final long serialVersionUID = 8505738900643528230L;
 	

--- a/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/AlpineSBomGenerator.java
+++ b/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/AlpineSBomGenerator.java
@@ -46,7 +46,7 @@ public class AlpineSBomGenerator extends UnixSBomGenerator
 	 * @return Bom The Software Bill Of Materials for this RedHat Linux Operating System.
 	 * @throws SBomException if we are unable to build the SBOM.
 	 */
-	public Bom generateSBom() throws SBomException
+	public Bom generateSBom()
 	{
 		List<String> softwareList = generateListOfSoftware(SOFTWARE_LIST_CMD, '\n',
 				null);
@@ -78,7 +78,7 @@ public class AlpineSBomGenerator extends UnixSBomGenerator
 	 * @return String the version of the software.
 	 * @throws SBomException if we are unable to run the command to get the version.
 	 */
-	public String getVersion(String software) throws SBomException
+	public String getVersion(String software)
 	{
 		String version = null;
 		
@@ -108,7 +108,6 @@ public class AlpineSBomGenerator extends UnixSBomGenerator
 	 * @throws SBomException if we are unable to read the version from the reader.
 	 */
 	public String parseVersion(BufferedReader reader)
-			throws SBomException
 	{
 		String version = null;
 		
@@ -154,7 +153,7 @@ public class AlpineSBomGenerator extends UnixSBomGenerator
 	 * @throws SBomException in the event we are unable to complete the processing of the unix
 	 *                       command.
 	 */
-	public String parseVersion(Process process, String cmd) throws SBomException
+	public String parseVersion(Process process, String cmd)
 	{
 		String version = null;
 		
@@ -194,7 +193,7 @@ public class AlpineSBomGenerator extends UnixSBomGenerator
 	 * @return Map containing the key value pairs about the software.
 	 * @throws SBomException in the event we can NOT produce the detail map of the software.
 	 */
-	private Map<String, String> produceDetailMap(String software) throws SBomException
+	private Map<String, String> produceDetailMap(String software)
 	{
 		String cmd = SOFTWARE_DETAIL_CMD + software;
 		

--- a/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/RedHatSBomGenerator.java
+++ b/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/RedHatSBomGenerator.java
@@ -54,7 +54,7 @@ public class RedHatSBomGenerator extends UnixSBomGenerator
 	 * @return Bom The Software Bill Of Materials for this RedHat Linux Operating System.
 	 * @throws SBomException if we are unable to build the SBOM.
 	 */
-	public Bom generateSBom() throws SBomException
+	public Bom generateSBom()
 	{
 		List<String> softwareList = generateListOfSoftware(SOFTWARE_LIST_CMD, ' ',
 				"Installed Packages");
@@ -127,7 +127,7 @@ public class RedHatSBomGenerator extends UnixSBomGenerator
 	 * @return String the URL that will be used to download this software product.
 	 * @throws SBomException in the event we are unable to get the PURL from the server.
 	 */
-	public String getPurl(String software) throws SBomException
+	public String getPurl(String software)
 	{
 		String purl = null;
 		
@@ -161,7 +161,7 @@ public class RedHatSBomGenerator extends UnixSBomGenerator
 	 * @return String the PURL if available.
 	 * @throws SBomException if we are unable to process the output of the YUM command.
 	 */
-	public String parsePurl(Process process, String software) throws SBomException
+	public String parsePurl(Process process, String software)
 	{
 		String purl = null;
 		
@@ -203,7 +203,7 @@ public class RedHatSBomGenerator extends UnixSBomGenerator
 	 * @return String the PURL or download URL that can be used to download the software package.
 	 * @throws SBomException in the event we are unable to parse the command's output.
 	 */
-	public String parsePurlCmdOutput(BufferedReader reader) throws SBomException
+	public String parsePurlCmdOutput(BufferedReader reader)
 	{
 		String purl = null;
 		try
@@ -279,7 +279,7 @@ public class RedHatSBomGenerator extends UnixSBomGenerator
 	 * @return Map containing the key value pairs about the software.
 	 * @throws SBomException in the event we can NOT produce the detail map of the software.
 	 */
-	private Map<String, String> produceDetailMap(String software) throws SBomException
+	private Map<String, String> produceDetailMap(String software)
 	{
 		String cmd = SOFTWARE_DETAIL_CMD + " " + software;
 		

--- a/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/SBomGenerator.java
+++ b/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/SBomGenerator.java
@@ -113,7 +113,6 @@ public class SBomGenerator
 	 * @throws SBomException if we are unable to produce the file.
 	 */
 	public static void createBomFile(Bom bom, SBomCommons.AVAILABLE_FORMATS format)
-			throws SBomException
 	{
 		File file = new File("output/bom." + format.toString().toLowerCase());
 		try (FileWriter writer = new FileWriter(file))
@@ -193,7 +192,7 @@ public class SBomGenerator
 	 * @param bom Bill of Materials to create the files form.
 	 * @throws SBomException in the event we can NOT create either the XML of JSon files.
 	 */
-	public static void geneateBoms(Bom bom) throws SBomException
+	public static void geneateBoms(Bom bom)
 	{
 		try
 		{	
@@ -221,7 +220,7 @@ public class SBomGenerator
 	 * @return int the number of programs found within the operating system.
 	 * @throws SBomException if we are unable to build the SBOM.
 	 */
-	public static int generateSBom(CommandLine cli) throws SBomException
+	public static int generateSBom(CommandLine cli)
 	{		
 		OperatingSystemUtils osUtils = new OperatingSystemUtils();
 		String vendor = osUtils.getOsVendor();

--- a/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/UbuntuSBomGenerator.java
+++ b/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/UbuntuSBomGenerator.java
@@ -47,7 +47,7 @@ public class UbuntuSBomGenerator extends UnixSBomGenerator
 	 * @return Bom The Software Bill Of Materials for this Ubuntu Linux Operating System.
 	 * @throws SBomException if we are unable to build the SBOM.
 	 */
-	public Bom generateSBom() throws SBomException
+	public Bom generateSBom()
 	{
 		List<String> softwareList = generateListOfSoftware(SOFTWARE_LIST_CMD, '/',
 				"");
@@ -86,7 +86,7 @@ public class UbuntuSBomGenerator extends UnixSBomGenerator
 	 * @return String value of the version of the software that is currently installed.
 	 * @throws SBomException in the event we can NOT get the version.
 	 */
-	public String getInstalledVersion(String software) throws SBomException
+	public String getInstalledVersion(String software)
 	{
 		String version = "";
 		
@@ -125,7 +125,7 @@ public class UbuntuSBomGenerator extends UnixSBomGenerator
 	 * @return String the version pulled from the reader.
 	 * @throws SBomException in the event we are unable to read from the Unix Command.
 	 */
-	public String parseVersion(BufferedReader reader) throws SBomException
+	public String parseVersion(BufferedReader reader)
 	{
 		String version = null;
 		
@@ -188,7 +188,7 @@ public class UbuntuSBomGenerator extends UnixSBomGenerator
 	 * @return Map containing the key value pairs about the software.
 	 * @throws SBomException in the event we can NOT produce the detail map of the software.
 	 */
-	private Map<String, String> produceDetailMap(String software) throws SBomException
+	private Map<String, String> produceDetailMap(String software)
 	{
 		String cmd = SOFTWARE_DETAIL_CMD + " " + software + "=" + getInstalledVersion(software);
 		
@@ -202,7 +202,7 @@ public class UbuntuSBomGenerator extends UnixSBomGenerator
 	 * @return String the version.
 	 * @throws SBomException in the event we are unable to process the command.
 	 */
-	public String readVersion(Process process) throws SBomException
+	public String readVersion(Process process)
 	{
 		String version = null;
 		try (BufferedReader reader = new BufferedReader(

--- a/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/UnixSBomGenerator.java
+++ b/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/UnixSBomGenerator.java
@@ -151,7 +151,6 @@ public class UnixSBomGenerator
 	 * @throws SBomException if we can NOT read from the reader passed in.
 	 */
 	public Map<String, String> generateAlpineDetailMap(BufferedReader reader)
-			throws SBomException
 	{
 		Map<String, String> detailMap = new HashMap<>();
 		
@@ -199,7 +198,7 @@ public class UnixSBomGenerator
 	 * @throws SBomException if we can NOT read from the reader passed in.
 	 */
 	public Map<String, String> generateDetailMap(BufferedReader reader,
-			AVAILABLE_LINUX_FLAVORS linuxFlavor) throws SBomException
+			AVAILABLE_LINUX_FLAVORS linuxFlavor)
 	{
 		Map<String, String> detailMap = new HashMap<>();
 		
@@ -275,7 +274,7 @@ public class UnixSBomGenerator
 	 *                       installed on the server.
 	 */
 	protected List<String> generateListOfSoftware(String cmd, char separator,
-			String preProcessingString) throws SBomException
+			String preProcessingString)
 	{
 		List<String> softwareList = new ArrayList<>();
 		
@@ -307,7 +306,6 @@ public class UnixSBomGenerator
 	 * @throws SBomException if we can NOT read from the reader passed in.
 	 */
 	public Map<String, String> generateRedHatDetailMap(BufferedReader reader)
-			throws SBomException
 	{
 		return (generateDetailMap(reader, AVAILABLE_LINUX_FLAVORS.REDHAT));
 	}
@@ -320,7 +318,6 @@ public class UnixSBomGenerator
 	 * @throws SBomException if we can NOT read from the reader passed in.
 	 */
 	public Map<String, String> generateUbuntuDetailMap(BufferedReader reader)
-			throws SBomException
 	{
 		return (generateDetailMap(reader, AVAILABLE_LINUX_FLAVORS.UBUNTU));
 	}
@@ -375,7 +372,7 @@ public class UnixSBomGenerator
 	 * @throws SBomException in the event we can NOT produce the detail map of the software.
 	 */
 	public Map<String, String> processDetailMapCommand(Process process,
-			AVAILABLE_LINUX_FLAVORS linuxFlavor) throws SBomException
+			AVAILABLE_LINUX_FLAVORS linuxFlavor)
 	{
 		Map<String, String> detailMap = new HashMap<>();
 
@@ -422,7 +419,7 @@ public class UnixSBomGenerator
 	 * @throws SBomException if we are unable to get the list of software.
 	 */
 	public List<String> processListCmdOutput(BufferedReader reader, char separator,
-			String preProcessingString) throws SBomException
+			String preProcessingString)
 	{
 		List<String> softwareList = new ArrayList<>();
 		
@@ -483,7 +480,7 @@ public class UnixSBomGenerator
 	 * @throws SBomException in the event we are unable to process the output of the Unix command.
 	 */
 	public List<String> processListOfSoftware(Process process, String cmd, char separator,
-			String preProcessingString) throws SBomException
+			String preProcessingString)
 	{
 		List<String> softwareList = new ArrayList<>();
 		
@@ -526,7 +523,7 @@ public class UnixSBomGenerator
 	 * @throws SBomException in the event we can NOT produce the detail map of the software.
 	 */
 	protected Map<String, String> produceDetailMap(String cmd,
-			AVAILABLE_LINUX_FLAVORS linuxFlavor) throws SBomException
+			AVAILABLE_LINUX_FLAVORS linuxFlavor)
 	{
 		Map<String, String> detailMap = new HashMap<>();
 		

--- a/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/utils/OperatingSystemUtils.java
+++ b/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/utils/OperatingSystemUtils.java
@@ -40,7 +40,7 @@ public class OperatingSystemUtils
 	 * 
 	 * @throws SBomException in the event we are unable to read the file.
 	 */
-	public OperatingSystemUtils() throws SBomException
+	public OperatingSystemUtils()
 	{
 		osMap = getOs();
 	}
@@ -120,7 +120,7 @@ public class OperatingSystemUtils
 	 * @return Map containing the information from the os-release file.
 	 * @throws SBomException in the event we are unable to read the file.
 	 */
-	public Map<String, String> getOs() throws SBomException
+	public Map<String, String> getOs()
 	{
 		Map<String, String> detailMap = new HashMap<>();
 		


### PR DESCRIPTION
As SBomException is almost never caught and handled, a runtime exception
makes sense.

Signed-off-by: Jurrie Overgoor <1213142+Jurrie@users.noreply.github.com>