### PR TITLE
Read the remainder of the process output so that it will exit

### DIFF
--- a/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/UbuntuSBomGenerator.java
+++ b/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/UbuntuSBomGenerator.java
@@ -210,6 +210,9 @@ public class UbuntuSBomGenerator extends UnixSBomGenerator
 		{
 			version = parseVersion(reader);
 			
+			// Read the remainder of the standard output, so that the process can finish
+			while (reader.read() != -1) {}
+			
 			int exitVal = process.waitFor();
 			if (exitVal != 0)
 			{


### PR DESCRIPTION
Without this addition...

* IF the `apt` command has a lot of output (happens with proprietary, non-public packages)
* THEN the `apt` command may fill it's standard output buffer, and hang waiting for buffer space
* This results in the `waitFor()` call on line 213 (216 after this change) to never return, since `apt` is waiting for this very code to empty the buffer

Proposed (and tested) solution: simply empty the buffer as is commonly required when using process builder.

Technically we should do the same for stderr, but I had a hard time imagining it dumping that much to stderr and wanted to keep this change small